### PR TITLE
ci: add GitHub Actions workflow for unit tests with coverage

### DIFF
--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -1,0 +1,69 @@
+name: ci-unittest
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up environment variables
+      run: |
+        echo "PATH=${HOME}/.local/bin:${HOME}/kcov/bin:${PATH}" >> $GITHUB_ENV
+
+    - name: Install dependencies (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y cmake binutils-dev libcurl4-openssl-dev libdw-dev libiberty-dev
+
+    - name: Install kcov (Linux)
+      if: runner.os == 'Linux'
+      run: |
+        wget https://github.com/SimonKagstrom/kcov/archive/master.tar.gz
+        tar xzf master.tar.gz
+        (cd kcov-master && (mkdir -p build && cd build && (cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov .. && make && make install)))
+        rm -rf kcov-master
+
+    - name: Install kcov (macOS)
+      if: runner.os == 'macOS'
+      run: |
+        brew install kcov
+
+    - name: Install shellspec
+      run: |
+        # git.io was shut down (2022); use shellspec's canonical installer URL.
+        curl -fsSL https://raw.githubusercontent.com/shellspec/shellspec/master/install.sh | sh -s -- -y
+
+    - name: Install xsh
+      run: |
+        bash install.sh -s
+
+    - name: Run tests
+      run: |
+        # Each GitHub Actions step is a fresh shell, so the xsh shell function
+        # defined by ~/.xshrc must be re-sourced here (PATH persists via GITHUB_ENV).
+        source ~/.xshrc
+        xsh version
+        shellspec --version
+        kcov --version
+        shellspec --list specfiles
+        shellspec --count
+        # start test with coverage
+        # run all specfiles at once otherwise the later coverage will override the former
+        # the order of the specfiles matters
+        shellspec --kcov -s /bin/bash spec/xsh_spec.sh spec/installer_spec.sh
+
+    - name: Upload coverage report
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: false

--- a/.github/workflows/ci-unittest.yml
+++ b/.github/workflows/ci-unittest.yml
@@ -11,7 +11,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI workflow (`ci-unittest`) that runs the in-repo ShellSpec suite (`spec/xsh_spec.sh`, `spec/installer_spec.sh`) with kcov coverage on `ubuntu-latest` and `macos-latest`. xsh currently has **no working CI** — the old Travis config (`.travis.yml`) is defunct since Travis sunset OSS builds.

This recovers a workflow draft that had been sitting **git-added-but-never-committed on `develop` for ~2 years**, and modernizes it so it actually runs on today's runners.

## Changes vs. the original draft
| Issue | Fix |
|---|---|
| `actions/checkout@v2` (EOL Node) | → `@v4` |
| shellspec installer used `https://git.io/shellspec` — **git.io was shut down in 2022**, so the step hard-fails | → canonical `raw.githubusercontent.com/shellspec/shellspec/master/install.sh` |
| `source ~/.xshrc` ran in the install step, but each Actions `run:` is a fresh shell (Travis shared one session) — `xsh` would be undefined in the test step | → re-source inside the **Run tests** step (PATH still persists via `GITHUB_ENV`) |
| `codecov/codecov-action@v1` (sunset bash uploader) | → `@v5` + `token: secrets.CODECOV_TOKEN` + `fail_ci_if_error: false` |
| matrix could cancel the sibling OS on first failure | → `fail-fast: false`; added `cmake` to Linux deps for the kcov source build |

## Notes
- Tests are **in-repo** under `spec/`; the separate `alexzhangs/xsh-test` repo is just a small fixture library, not the suite — nothing needs to pull it.
- Coverage upload needs a `CODECOV_TOKEN` repo secret to be reliable on the current Codecov; `fail_ci_if_error: false` keeps the build green if it's absent.
- Residual risk to watch on the first run: kcov-from-source on the latest Ubuntu and `brew install kcov` on the arm64 macOS runner are the most environment-sensitive steps.

## Follow-ups (out of scope here)
- README still has a dead Travis badge (line 5); swap for an Actions badge once this lands.
- `.travis.yml` can be removed after this is confirmed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)