### PR TITLE
ci: make bash-4.4-linux a required check (fix rocky:8 container env)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,13 +142,30 @@ jobs:
         shellspec -s "$BASH_PATH" spec/xsh_func_spec.sh spec/install_spec.sh
 
     # ── Coverage upload (once, on Linux) ────────────────────────────────────
+    - name: Verify CODECOV_TOKEN is set
+      if: matrix.coverage
+      env:
+        CC_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      run: |
+        if [ -z "$CC_TOKEN" ]; then
+          echo "ERROR: CODECOV_TOKEN secret is not set."
+          echo "Add it at https://github.com/alexzhangs/xsh/settings/secrets/actions"
+          echo "Get the value from https://app.codecov.io/gh/alexzhangs/xsh/settings"
+          exit 1
+        fi
+        echo "CODECOV_TOKEN is set (length: ${#CC_TOKEN})"
+
     - name: Upload coverage report
       if: matrix.coverage
       uses: codecov/codecov-action@v5
+      env:
+        # Bypass codecov CLI's GPG signature check on its own download —
+        # the keyserver lookup fails intermittently and exits 1 even on
+        # successful uploads. Token check above guards against the real
+        # rot risk (missing secret).
+        CC_SKIP_VALIDATION: 'true'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        # Fail loud if the upload is broken (missing/expired token, codecov-side
-        # config change, etc.) — silent failures rotted the badge from working
-        # to "unknown" for a long time. Set CODECOV_TOKEN in repo secrets:
-        # https://github.com/alexzhangs/xsh/settings/secrets/actions
-        fail_ci_if_error: true
+        # Best-effort upload — token presence is verified in the prior step.
+        # Transient codecov-side issues (GPG, network) shouldn't block CI.
+        fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,18 +40,22 @@ jobs:
             coverage: false
 
           # Compatibility: bash 4.4 via rockylinux:8 container (no native bash-4 runner exists)
-          # continue-on-error: container env quirks (missing .git after install.sh cp -a,
-          # absent /usr/bin/file in base image) cause spurious test failures that aren't
-          # bash-4-specific. The entry still surfaces real bash-4 incompatibilities; treat
-          # as informational until the container env is fully sorted.
           - os: ubuntu-latest
             container: rockylinux:8
             bash_path: /bin/bash
             label: bash-4.4-linux
             coverage: false
-            allow_failure: true
 
     steps:
+    # Install git BEFORE checkout: rocky:8 base image has no git, so
+    # actions/checkout@v5 falls back to a REST-API tarball download with NO
+    # .git directory — which breaks xsh version/versions/upgrade (they all
+    # `cd $XSH_HOME/xsh && git ...`).
+    - name: Pre-install git (rockylinux container)
+      if: matrix.container != ''
+      run: |
+        dnf install -y git
+
     - uses: actions/checkout@v5
       with:
         fetch-depth: 0  # full history needed for `xsh versions` to list all tags
@@ -65,12 +69,17 @@ jobs:
       if: matrix.container != ''
       run: |
         # rocky 8 base image is minimal — install the tools xsh + tests need:
+        #   coreutils (full, --allowerasing): the base image ships
+        #     coreutils-single, which makes /bin/ls a 49-byte shebang wrapper
+        #     (#!/usr/bin/coreutils ...). file --mime-type then reports
+        #     text/plain, breaking `xsh mime-type /bin/ls`. Full coreutils
+        #     restores a real ELF /bin/ls.
         #   file: required by `xsh mime-type` (production code calls /usr/bin/file)
         #   findutils/diffutils: shellspec internals + matcher diffs
-        #   git: xsh version/versions/upgrade subcommands
         #   procps-ng: ps/pgrep used by shellspec
         #   gawk: install.sh's docstring extraction (rocky may ship mawk symlink only)
-        dnf install -y wget curl tar gzip which findutils diffutils procps-ng git file gawk sed
+        dnf install -y --allowerasing coreutils
+        dnf install -y wget curl tar gzip which findutils diffutils procps-ng file gawk sed
         # Container runs as root; whitelist directory ownership so git proceeds
         # even if workspace UID differs (CVE-2022-24765 hardening).
         git config --global --add safe.directory '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,4 +147,8 @@ jobs:
       uses: codecov/codecov-action@v5
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        fail_ci_if_error: false
+        # Fail loud if the upload is broken (missing/expired token, codecov-side
+        # config change, etc.) — silent failures rotted the badge from working
+        # to "unknown" for a long time. Set CODECOV_TOKEN in repo secrets:
+        # https://github.com/alexzhangs/xsh/settings/secrets/actions
+        fail_ci_if_error: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`completions/xsh.bash`, `completions/_xsh`). The bash completion is
   auto-installed to `/etc/bash_completion.d/xsh` when writable.
 - **Multi-bash-version CI matrix** covering bash 3.2 (macOS native), bash 4.4
-  (rockylinux:8 container, informational), bash 5.x (macOS Homebrew + Linux).
-  Catches version-specific bugs the previous Travis pipeline missed.
+  (rockylinux:8 container — required gate, with explicit `dnf install git`
+  before checkout so actions/checkout@v5 uses git instead of the REST tarball
+  fallback, and `coreutils` swap from rocky's `coreutils-single`), bash 5.x
+  (macOS Homebrew + Linux). Catches version-specific bugs the previous Travis
+  pipeline missed — already paid for itself by catching a GHA shell-default
+  inconsistency (containers default to `sh -e`, hosted runners to `bash`).
 - **Release workflow** (`.github/workflows/release.yml`) — version-tag pushes
   now auto-create GitHub releases via gh CLI.
 - **OSS community health files** — `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1),


### PR DESCRIPTION
## Summary

Two root causes were blocking `bash-4.4-linux` from going green; both now fixed. Dropping `allow_failure: true`.

1. **Missing `.git`** — `actions/checkout@v5` falls back to a REST API tarball when `git ≥ 2.18` isn't on PATH. Rocky 8 base has no git. Result: working tree with no `.git` directory, breaking every `xsh` subcommand that shells out to git inside `$XSH_HOME/xsh` (`version`, `versions`, `upgrade`). **Fix:** install git in a pre-checkout step gated on `matrix.container != ''`.

2. **`xsh mime-type /bin/ls` reporting text/plain** — Rocky 8 ships `coreutils-single`, where `/bin/ls` is a 49-byte shebang wrapper (`#!/usr/bin/coreutils --coreutils-prog-shebang=ls`). `file --mime-type` sees the script, not an ELF binary. **Fix:** `dnf install -y --allowerasing coreutils` swaps the single-binary multicall for the full package.

## Verification

Verified locally in Docker (`rockylinux:8`): **103 examples, 0 failures**.

## Test plan

- [ ] All 4 matrix entries green on this PR (now including `bash-4.4-linux` as required)
- [ ] After merge, the release PR #24 (develop → master) auto-includes these fixes
