### PR TITLE
spec: correct __xsh_get_util_by_path selector test

### DIFF
--- a/spec/xsh_func_spec.sh
+++ b/spec/xsh_func_spec.sh
@@ -552,15 +552,13 @@ Describe 'xsh.sh'
         The output should equal 'upper'
       End
 
-      It 'strips a leading numeric selector before the util name'
-        # Production bug: ${util%/[0-9]*} matches the whole '/2-upper' segment
-        # instead of just the '2-' prefix, so the function returns 'string'
-        # rather than 'upper'. ShellSpec Pending flips this to a failure when
-        # the bug is fixed, forcing the fixer to remove the marker.
-        Pending 'production bug: __xsh_get_util_by_path strips wrong segment'
-        When call xsh get-util-by-path '/some/lib/functions/string/2-upper.sh'
+      It 'strips a trailing numeric selector file from the util directory'
+        # xsh-lib/core convention: a util may be split across selector files
+        # under a directory named for the util (e.g. string/repeat/{1,2,...}.sh).
+        # The util name is the parent directory, not the selector filename.
+        When call xsh get-util-by-path '/some/lib/functions/string/repeat/1.sh'
         The status should be success
-        The output should equal 'upper'
+        The output should equal 'repeat'
       End
     End
 


### PR DESCRIPTION
## Summary
- The Pending case at `spec/xsh_func_spec.sh` assumed selectors were encoded as a leading `<N>-` basename prefix (`2-upper.sh`) and treated the existing impl as buggy.
- Audit of the four call sites (xsh.sh:855, 1479, 1627, 1913) plus a survey of every `xsh-lib/*` repo on disk found **zero** files matching `[0-9]+-*.sh`. The actual convention in `xsh-lib/core` is the opposite: the util is a directory, the selector is a plain-numeric filename inside it (e.g. `string/repeat/{1..8}.sh`, `array/last/{1,2}.sh`, `math/{dec2hex,hex2dec}/{1,2}.sh`, `string/set/mxn/{1,2}.sh`).
- Existing `__xsh_get_util_by_path` already handles that form correctly via `${util%/[0-9]*}` + basename (verified: `repeat/1.sh -> repeat`, `last/2.sh -> last`).
- Replaces the Pending block with a passing test that pins the real contract. **No production code change.**

## Test plan
- [x] Verified existing impl by reproducing parameter expansion outside the test harness on `string/repeat/1.sh`, `string/upper.sh`, `array/last/2.sh` — returns `repeat`, `upper`, `last` respectively.
- [x] `shellspec -s /bin/bash spec/xsh_func_spec.sh spec/install_spec.sh` locally — host-env failures (`XSH_HOME is not set properly`) are pre-existing and apply to the whole `additional coverage` section; CI sandbox is required for full pass. The new `It` block matches the shape of the sibling passing test.
- [ ] CI green on PR.