### PR TITLE
sync: develop → master (spec test correction for __xsh_get_util_by_path)

### DIFF
--- a/spec/xsh_func_spec.sh
+++ b/spec/xsh_func_spec.sh
@@ -552,15 +552,13 @@ Describe 'xsh.sh'
         The output should equal 'upper'
       End
 
-      It 'strips a leading numeric selector before the util name'
-        # Production bug: ${util%/[0-9]*} matches the whole '/2-upper' segment
-        # instead of just the '2-' prefix, so the function returns 'string'
-        # rather than 'upper'. ShellSpec Pending flips this to a failure when
-        # the bug is fixed, forcing the fixer to remove the marker.
-        Pending 'production bug: __xsh_get_util_by_path strips wrong segment'
-        When call xsh get-util-by-path '/some/lib/functions/string/2-upper.sh'
+      It 'strips a trailing numeric selector file from the util directory'
+        # xsh-lib/core convention: a util may be split across selector files
+        # under a directory named for the util (e.g. string/repeat/{1,2,...}.sh).
+        # The util name is the parent directory, not the selector filename.
+        When call xsh get-util-by-path '/some/lib/functions/string/repeat/1.sh'
         The status should be success
-        The output should equal 'upper'
+        The output should equal 'repeat'
       End
     End
 


### PR DESCRIPTION
## Summary
Bring `develop` to `master`. One commit, spec-only — no production code change:

- [#26](https://github.com/alexzhangs/xsh/pull/26) `spec: correct __xsh_get_util_by_path selector test` — the Pending test was based on a wrong assumption about the selector convention (`[0-9]+-name.sh`). Real `xsh-lib/core` convention is `<util>/<N>.sh` (e.g. `string/repeat/{1..8}.sh`), which existing code already handles. Replaces the Pending block with a passing test pinning the real contract.

No version bump — keeping `master` in sync with `develop`, but `0.6.1` is not warranted for a spec-only fix one day after `0.6.0`.

## Test plan
- [x] PR #26 CI green (all 8 checks, codecov green)
- [x] Diff gate: `git log origin/master..origin/develop` shows exactly one commit (e5df7b1), touching only `spec/xsh_func_spec.sh`
- [ ] CI green on this sync PR