### PR TITLE
feat: bash completion works on stock macOS bash 3.2 (no bash-completion dep)

### DIFF
--- a/.xshrc
+++ b/.xshrc
@@ -11,3 +11,7 @@
 export XSH_HOME=~/.xsh
 export XSH_DEV_HOME=${XSH_HOME}/lib-dev
 . ${XSH_HOME}/xsh/xsh.sh
+
+# Bash tab-completion for `xsh`. Self-sufficient on stock macOS bash 3.2 via
+# its own _init_completion fallback; no bash-completion package required.
+[ -r "${XSH_HOME}/xsh/completions/xsh.bash" ] && . "${XSH_HOME}/xsh/completions/xsh.bash"

--- a/completions/xsh.bash
+++ b/completions/xsh.bash
@@ -1,3 +1,24 @@
+# Minimal fallback for systems without bash-completion installed (notably
+# stock macOS /bin/bash 3.2.57, where bash-completion@2 requires bash 4+ and
+# silently bails). The real _init_completion handles edge cases this shim
+# skips (quoting, redirection), but populates the same four caller-local
+# variables this completer reads. Defined only if not already present, so a
+# later bash-completion load wins.
+if ! declare -F _init_completion >/dev/null 2>&1; then
+    _init_completion() {
+        COMPREPLY=()
+        # Match real _init_completion: bail when cword <= 0 (degenerate case
+        # that real completion never triggers, but bash 3.2 errors on
+        # ${COMP_WORDS[-1]} before the ${...:-} default can apply).
+        [[ ${COMP_CWORD:-0} -gt 0 ]] || return 1
+        cur=${COMP_WORDS[COMP_CWORD]}
+        prev=${COMP_WORDS[COMP_CWORD-1]}
+        words=("${COMP_WORDS[@]}")
+        cword=$COMP_CWORD
+        return 0
+    }
+fi
+
 _xsh_complete() {
     local cur prev words cword
     _init_completion || return

--- a/install.sh
+++ b/install.sh
@@ -182,10 +182,9 @@ function install-xsh () {
     printf "updating: %s\n" ~/.bashrc
     update-profile ~/.bashrc
 
-    # install bash completion if available
-    if [[ -d /etc/bash_completion.d ]]; then
-        cp "${SCRIPT_DIR}/completions/xsh.bash" /etc/bash_completion.d/xsh 2>/dev/null || true
-    fi
+    # Bash completion is now auto-sourced by ~/.xshrc (see .xshrc); the previous
+    # /etc/bash_completion.d/ copy was redundant on Linux and a no-op on macOS
+    # (no such dir on stock macOS; Homebrew uses $(brew --prefix)/etc/...).
 }
 
 function main () {


### PR DESCRIPTION
## Summary

Tab completion in 0.6.0 silently does nothing on **stock macOS** because:
- `/bin/bash` is 3.2.57
- `bash-completion@2` requires bash 4+ and bails silently
- `completions/xsh.bash`'s first line is `_init_completion || return` → returns immediately

Three small coordinated changes make it work out of the box:

### 1. `completions/xsh.bash` — `_init_completion` fallback shim
Defined only if not already present (so a real bash-completion load wins, whether earlier or later). Sets the same four caller-local variables the completer reads. Defensive `cword <= 0` guard matches real `_init_completion` semantics and avoids bash 3.2's bad-array-subscript error on `${COMP_WORDS[-1]}`.

### 2. `.xshrc` — auto-source the completion file
Users don't have to touch `~/.bash_profile` or rely on `/etc/bash_completion.d/` discovery (which doesn't exist on stock macOS).

### 3. `install.sh` — drop the now-redundant `/etc/bash_completion.d/xsh` copy
That copy was a no-op on macOS (no such dir) and double-sourced on Linux once `.xshrc` auto-source landed.

## Verified

Stock `/bin/bash` 3.2.57, **no bash-completion package installed**:

```
$ xsh <TAB><TAB>
load unload update list imports unimports import unimport help debug
version versions upgrade calls call exec log lib-manager lib-dev-manager
+ 200+ LPUEs from loaded libs

$ xsh load <TAB><TAB>
xsh-lib/aws  xsh-lib/core  xsh-lib/git
```

Also verified the shim does NOT override a pre-existing `_init_completion` (when bash-completion is loaded earlier).

## Test plan

- [ ] CI green (matrix: bash 3.2 macOS / bash 4.4 rocky / bash 5.x macOS+Linux)
- [ ] After merge: existing 0.6.0 users get the fix by re-running `bash install.sh -f -s` or via `xsh upgrade`
