### PR TITLE
Release 0.6.1 — bash completion fix for stock macOS bash 3.2

### DIFF
--- a/.xshrc
+++ b/.xshrc
@@ -11,3 +11,7 @@
 export XSH_HOME=~/.xsh
 export XSH_DEV_HOME=${XSH_HOME}/lib-dev
 . ${XSH_HOME}/xsh/xsh.sh
+
+# Bash tab-completion for `xsh`. Self-sufficient on stock macOS bash 3.2 via
+# its own _init_completion fallback; no bash-completion package required.
+[ -r "${XSH_HOME}/xsh/completions/xsh.bash" ] && . "${XSH_HOME}/xsh/completions/xsh.bash"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-06-08
+
+### Fixed
+
+- **Bash tab-completion now works on stock macOS bash 3.2** without requiring
+  the `bash-completion` package. The 0.6.0 completion script called
+  `_init_completion` from bash-completion, which on macOS native `/bin/bash`
+  (3.2.57) was silently absent because `bash-completion@2` requires bash 4+
+  and bails. The completion script now ships an `_init_completion` fallback
+  shim guarded by `declare -F` — a real bash-completion load (now or later)
+  still wins, so behavior on Linux and bash-completion-enabled setups is
+  unchanged.
+- `.xshrc` now auto-sources the completion file, so users don't need to
+  edit `~/.bash_profile` or rely on `/etc/bash_completion.d/` discovery
+  (which doesn't exist on stock macOS).
+
+### Removed
+
+- `install.sh` no longer copies `xsh.bash` into `/etc/bash_completion.d/` —
+  redundant on Linux (now sourced via `.xshrc`) and a no-op on macOS.
+
+### Changed
+
+- **Test correction** — the `__xsh_get_util_by_path` Pending test added in
+  0.6.0 assumed selectors are encoded as a leading `<N>-` basename prefix
+  (e.g. `2-upper.sh`). Every selector in xsh-lib/core actually uses the
+  opposite convention: the util is a directory, selectors are plain-numeric
+  filenames inside it (e.g. `string/repeat/{1..8}.sh`). The existing
+  implementation already strips that form correctly. Test replaced with a
+  passing assertion of the real convention; no production code change.
+
 ## [0.6.0] - 2026-06-08
 
 ### Added
@@ -163,7 +194,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial working implementation: load scripts, functions, and the bash library framework.
 
-[Unreleased]: https://github.com/alexzhangs/xsh/compare/0.6.0...HEAD
+[Unreleased]: https://github.com/alexzhangs/xsh/compare/0.6.1...HEAD
+[0.6.1]: https://github.com/alexzhangs/xsh/compare/0.6.0...0.6.1
 [0.6.0]: https://github.com/alexzhangs/xsh/compare/0.5.3...0.6.0
 [0.5.3]: https://github.com/alexzhangs/xsh/compare/0.5.2...0.5.3
 [0.5.2]: https://github.com/alexzhangs/xsh/compare/0.5.1...0.5.2

--- a/completions/xsh.bash
+++ b/completions/xsh.bash
@@ -1,3 +1,24 @@
+# Minimal fallback for systems without bash-completion installed (notably
+# stock macOS /bin/bash 3.2.57, where bash-completion@2 requires bash 4+ and
+# silently bails). The real _init_completion handles edge cases this shim
+# skips (quoting, redirection), but populates the same four caller-local
+# variables this completer reads. Defined only if not already present, so a
+# later bash-completion load wins.
+if ! declare -F _init_completion >/dev/null 2>&1; then
+    _init_completion() {
+        COMPREPLY=()
+        # Match real _init_completion: bail when cword <= 0 (degenerate case
+        # that real completion never triggers, but bash 3.2 errors on
+        # ${COMP_WORDS[-1]} before the ${...:-} default can apply).
+        [[ ${COMP_CWORD:-0} -gt 0 ]] || return 1
+        cur=${COMP_WORDS[COMP_CWORD]}
+        prev=${COMP_WORDS[COMP_CWORD-1]}
+        words=("${COMP_WORDS[@]}")
+        cword=$COMP_CWORD
+        return 0
+    }
+fi
+
 _xsh_complete() {
     local cur prev words cword
     _init_completion || return

--- a/install.sh
+++ b/install.sh
@@ -182,10 +182,9 @@ function install-xsh () {
     printf "updating: %s\n" ~/.bashrc
     update-profile ~/.bashrc
 
-    # install bash completion if available
-    if [[ -d /etc/bash_completion.d ]]; then
-        cp "${SCRIPT_DIR}/completions/xsh.bash" /etc/bash_completion.d/xsh 2>/dev/null || true
-    fi
+    # Bash completion is now auto-sourced by ~/.xshrc (see .xshrc); the previous
+    # /etc/bash_completion.d/ copy was redundant on Linux and a no-op on macOS
+    # (no such dir on stock macOS; Homebrew uses $(brew --prefix)/etc/...).
 }
 
 function main () {


### PR DESCRIPTION
## Summary

Patch release fixing the 0.6.0 tab-completion regression on stock macOS bash 3.2.

### What's in 0.6.1

**Fixed**
- Bash tab-completion now works on stock macOS bash 3.2 without requiring `bash-completion`. The 0.6.0 script depended on `_init_completion` from `bash-completion@2` which silently bails on bash 3.2. Now ships a self-contained fallback shim, guarded so a real bash-completion load (now or later) still wins.
- `.xshrc` auto-sources the completion file — no need to touch `~/.bash_profile` or `/etc/bash_completion.d/`.

**Removed**
- `install.sh` no longer copies to `/etc/bash_completion.d/` (redundant after `.xshrc` auto-source; was a no-op on macOS anyway).

**Changed**
- Test correction (#26): the `__xsh_get_util_by_path` `Pending` test in 0.6.0 was based on a wrong assumption about selector encoding. xsh-lib/core uses plain-numeric filenames inside util directories (e.g. `string/repeat/{1..8}.sh`), not basename prefixes like `2-upper.sh`. Existing implementation was correct; test replaced with a passing assertion of the real convention.

### Why MINOR doesn't bump

Per SemVer pre-1.0: bug fixes → PATCH. No API changes, no removed features (just CI/installer cleanup).

### Test plan

- [ ] All 4 matrix entries green (verified locally and on the feature PR)
- [ ] After merge: tag `0.6.1` → `release.yml` auto-creates GitHub release from CHANGELOG.md
- [ ] On install: stock macOS bash 3.2 users get working tab-completion via `bash install.sh -f -s` (or `xsh upgrade`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
