### PR TITLE
Release 0.7.0 — zsh support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,29 +21,43 @@ jobs:
           # Primary: quality gate — ShellCheck + full test suite + kcov coverage
           - os: ubuntu-latest
             container: ''
-            bash_path: /bin/bash
+            shell_path: /bin/bash
             label: bash-5.x-linux
             coverage: true
 
-          # Compatibility: macOS default shell (bash 3.2) — the strictest target
+          # Compatibility: macOS system bash (bash 3.2) — the strictest bash target
           - os: macos-latest
             container: ''
-            bash_path: /bin/bash
+            shell_path: /bin/bash
             label: bash-3.2-macos
             coverage: false
 
           # Compatibility: macOS Homebrew bash (modern 5.x on macOS)
           - os: macos-latest
             container: ''
-            bash_path: brew
+            shell_path: brew
             label: bash-5.x-macos
             coverage: false
 
           # Compatibility: bash 4.4 via rockylinux:8 container (no native bash-4 runner exists)
           - os: ubuntu-latest
             container: rockylinux:8
-            bash_path: /bin/bash
+            shell_path: /bin/bash
             label: bash-4.4-linux
+            coverage: false
+
+          # Compatibility: macOS default shell (zsh) — the macOS login shell since Catalina
+          - os: macos-latest
+            container: ''
+            shell_path: /bin/zsh
+            label: zsh-5.x-macos
+            coverage: false
+
+          # Compatibility: zsh on Linux
+          - os: ubuntu-latest
+            container: ''
+            shell_path: /usr/bin/zsh
+            label: zsh-5.x-linux
             coverage: false
 
     steps:
@@ -90,6 +104,11 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y cmake binutils-dev libcurl4-openssl-dev libdw-dev libiberty-dev shellcheck
 
+    - name: Install zsh (Linux)
+      if: runner.os == 'Linux' && contains(matrix.shell_path, 'zsh')
+      run: |
+        sudo apt-get install -y zsh
+
     - name: Install kcov (Linux)
       if: matrix.coverage && runner.os == 'Linux'
       run: |
@@ -98,23 +117,23 @@ jobs:
         (cd kcov-43 && (mkdir -p build && cd build && (cmake -DCMAKE_INSTALL_PREFIX=${HOME}/kcov .. && make && make install)))
         rm -rf kcov-43
 
-    # ── macOS: resolve BASH_PATH from matrix ────────────────────────────────
+    # ── Resolve SHELL_PATH from matrix ──────────────────────────────────────
     - name: Install Homebrew bash
-      if: matrix.bash_path == 'brew'
+      if: matrix.shell_path == 'brew'
       run: |
         brew install bash
-        echo "BASH_PATH=$(brew --prefix)/bin/bash" >> $GITHUB_ENV
+        echo "SHELL_PATH=$(brew --prefix)/bin/bash" >> $GITHUB_ENV
 
-    - name: Set bash path
-      if: matrix.bash_path != 'brew'
+    - name: Set shell path
+      if: matrix.shell_path != 'brew'
       run: |
-        echo "BASH_PATH=${{ matrix.bash_path }}" >> $GITHUB_ENV
+        echo "SHELL_PATH=${{ matrix.shell_path }}" >> $GITHUB_ENV
 
     # ── ShellCheck (once, on Linux — skipped in the rockylinux container) ───
     - name: Run ShellCheck
       if: runner.os == 'Linux' && matrix.container == ''
       run: |
-        shellcheck xsh.sh install.sh boot
+        shellcheck xsh.sh install.sh boot bin/xsh
 
     # ── ShellSpec ────────────────────────────────────────────────────────────
     - name: Install shellspec
@@ -133,13 +152,13 @@ jobs:
         # Pass all specfiles in ONE shellspec invocation so kcov produces a single
         # merged coverage report. Splitting into multiple `shellspec --kcov` calls
         # would overwrite the report on each call (kcov_preprocess clears prior data).
-        shellspec --kcov -s "$BASH_PATH" spec/xsh_func_spec.sh spec/install_spec.sh
+        shellspec --kcov -s "$SHELL_PATH" spec/xsh_func_spec.sh spec/install_spec.sh
 
     - name: Run tests
       if: matrix.coverage != true
       run: |
         source ~/.xshrc
-        shellspec -s "$BASH_PATH" spec/xsh_func_spec.sh spec/install_spec.sh
+        shellspec -s "$SHELL_PATH" spec/xsh_func_spec.sh spec/install_spec.sh
 
     # ── Coverage upload (once, on Linux) ────────────────────────────────────
     - name: Verify CODECOV_TOKEN is set

--- a/.xshrc
+++ b/.xshrc
@@ -1,17 +1,42 @@
-# xsh requires bash; zsh support is planned — skip gracefully for now
-[ -z "${BASH_VERSION:-}" ] && return 2>/dev/null; :
+# xsh supports bash and zsh; skip gracefully for any other shell
+if [ -z "${BASH_VERSION:-}" ] && [ -z "${ZSH_VERSION:-}" ]; then
+    return 2>/dev/null
+fi
 
 #? Description:
 #?   This file is used by xsh - https://github.com/alexzhangs/xsh
 #?
 #? Usage:
-#?   . ~/.xshrc  # add this line to your ~/.bash_profile and ~/.bashrc
+#?   . ~/.xshrc  # add this line to your ~/.bash_profile, ~/.bashrc and ~/.zshrc
 #?
 
 export XSH_HOME=~/.xsh
 export XSH_DEV_HOME=${XSH_HOME}/lib-dev
-. ${XSH_HOME}/xsh/xsh.sh
+. "${XSH_HOME}/xsh/xsh.sh"
 
-# Bash tab-completion for `xsh`. Self-sufficient on stock macOS bash 3.2 via
-# its own _init_completion fallback; no bash-completion package required.
-[ -r "${XSH_HOME}/xsh/completions/xsh.bash" ] && . "${XSH_HOME}/xsh/completions/xsh.bash"
+# Make the executable shim `bin/xsh` available to sub-processes.
+# It is required under zsh - zsh cannot export functions to the environment;
+# it is harmless under bash - the exported xsh function takes precedence.
+case ":${PATH}:" in
+    *":${XSH_HOME}/xsh/bin:"*)
+        ;;
+    *)
+        export PATH=${XSH_HOME}/xsh/bin:${PATH}
+        ;;
+esac
+
+if [ -n "${BASH_VERSION:-}" ]; then
+    # Bash tab-completion for `xsh`. Self-sufficient on stock macOS bash 3.2 via
+    # its own _init_completion fallback; no bash-completion package required.
+    [ -r "${XSH_HOME}/xsh/completions/xsh.bash" ] && . "${XSH_HOME}/xsh/completions/xsh.bash"
+elif [ -n "${ZSH_VERSION:-}" ]; then
+    # Zsh tab-completion for `xsh` (completions/_xsh).
+    # If compinit has not run yet (this file is sourced before it in ~/.zshrc),
+    # registering the directory in fpath is enough - compinit will pick it up.
+    # If compinit has already run, bind the completer explicitly.
+    fpath=("${XSH_HOME}/xsh/completions" $fpath)
+    if (( $+functions[compdef] )); then
+        autoload -Uz _xsh
+        compdef _xsh xsh
+    fi
+fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-14
+
 ### Added
 
 - **zsh support** — xsh now runs under zsh (the default login shell on macOS

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **zsh support** — xsh now runs under zsh (the default login shell on macOS
+  since Catalina), in addition to bash 3.2+.
+  - `xsh()` and all its internal functions execute under zsh's ksh emulation
+    (`emulate -L ksh`, scoped to the call), providing the bash-style 0-indexed
+    arrays and word splitting the codebase relies on. Imported function
+    utilities get an `emulate -L ksh` line injected at import time, so
+    bash-flavored library code keeps working when called directly from the
+    zsh prompt.
+  - New executable shim `bin/xsh` (put on PATH by `~/.xshrc`): zsh cannot
+    export functions to the environment, so sub-processes (e.g. library
+    script utilities calling `xsh`) go through the shim. Under bash the
+    exported function takes precedence and the shim is inert.
+  - `~/.xshrc` is now bash/zsh-aware and `install.sh` registers it in
+    `~/.zshrc` too (and cleans it on uninstall).
+  - Zsh tab-completion: the existing `completions/_xsh` is now wired up by
+    `~/.xshrc` (fpath registration, or direct `compdef` if compinit already
+    ran), and its builtin list was synced with the bash completer.
+  - Hard bash-isms replaced with portable or shell-aware equivalents:
+    `${!#}` → `${*: -1}`, `type -t` → `__xsh_type_t` (zsh: `whence -w`),
+    `declare -p`-based export check → `__xsh_is_exported`, `FUNCNAME` →
+    built from zsh's `funcstack` where needed, bash `RETURN` trap →
+    function-scoped EXIT trap under zsh (`NO_POSIX_TRAPS`).
+  - All local variables named `path` renamed to `lpu_path`: in zsh, `path`
+    is tied to `PATH`, and assigning a scalar to it clobbers command lookup
+    for the function's lifetime.
+  - CI: new `zsh-5.x-macos` and `zsh-5.x-linux` jobs run the full test suite
+    under zsh (`shellspec -s <zsh>`); matrix key `bash_path` renamed to
+    `shell_path`.
+  - Known limitation: library utilities depending on bash-only features
+    (e.g. the `RETURN` trap used by `xsh-lib/core`'s `x/trap/return`, which
+    `x/file/inject` builds on) need a library-side update to work under zsh.
+  - Spec suite: examples asserting bash-only behavior (`$-` containing `h`,
+    exported functions) are now shell-aware; `xsh upgrade`/installer examples
+    that check out released tags are skipped under zsh until the first
+    zsh-supporting release is tagged.
+
 ## [0.6.2] - 2026-06-11
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ xsh is an e<span style="color:red">__x__</span>tension of ba<span style="color:r
 
 xsh aimed to provide a uniform and easy way to reuse bash code, like what a library does.
 
+xsh also runs under zsh — the default shell on modern macOS. See [Requirements](#31-requirements) for the details.
+
 xsh - this repository, in a narrow sense, is not a library itself. It's just a framework, in a broad sense xsh along with other repositories, such as `xsh-lib/core` as a whole, is a bash library with a framework.
 
 Why started this?
@@ -64,7 +66,7 @@ In a narrow sense, xsh (this repo) is just the framework — a single sourced fu
 
 * Easy to bootstrap(install).
 
-  The only thing you need is a bash and Git client.
+  The only thing you need is a bash (or zsh) and Git client. The installer itself runs with bash.
 
   ```bash
   $ git clone https://github.com/alexzhangs/xsh
@@ -131,7 +133,7 @@ Of course, some of the above topics can be built as libraries, packages, or util
 
 ## 3. xsh Bootstrap/Installation
 
-The only thing you need is a bash and Git client.
+The only thing you need is a bash (or zsh) and Git client. The installer itself runs with bash.
 
 ```bash
 $ git clone https://github.com/alexzhangs/xsh
@@ -151,7 +153,12 @@ $ curl -s https://raw.githubusercontent.com/alexzhangs/xsh/master/boot | bash &&
 
 ### 3.1. Requirements
 
-* **bash 3.2+** — xsh uses `declare -a` (indexed arrays) and `[[ =~ ]]` (regex matching), both introduced in bash 3.2. macOS ships with bash 3.2 at `/bin/bash` and is fully compatible.
+* **bash 3.2+ or zsh 5.x** — the shell that sources xsh.
+  * bash: xsh uses `declare -a` (indexed arrays) and `[[ =~ ]]` (regex matching), both introduced in bash 3.2. macOS ships with bash 3.2 at `/bin/bash` and is fully compatible.
+  * zsh: the default login shell on macOS since Catalina. xsh runs the `xsh` function and the imported utilities under zsh's ksh emulation (`emulate -L ksh`), which provides the bash-style 0-indexed arrays and word splitting that xsh libraries rely on. Notes specific to zsh:
+    * zsh cannot export functions to the environment, so sub-processes (e.g. library script utilities) reach xsh through the executable shim `bin/xsh`, which `~/.xshrc` puts on PATH.
+    * Library utilities are bash-flavored code; most run fine under the ksh emulation, but utilities depending on bash-only features (e.g. the `RETURN` trap used by `xsh-lib/core`'s `x/trap/return`) need a library-side update to work under zsh.
+  * The installer (`install.sh`) registers `~/.xshrc` in `~/.bash_profile`, `~/.bashrc`, and `~/.zshrc`, so xsh is available no matter which of the two shells you log into.
 * **git 2.x+** — used to clone and manage xsh libraries.
 * **curl** — used by the one-liner bootstrap only; not required for the `git clone` install path.
 

--- a/bin/xsh
+++ b/bin/xsh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+#? Description:
+#?   Executable shim for xsh.
+#?   It lets sub-processes call `xsh` when the parent shell could not export
+#?   the xsh function to the environment - e.g. when the parent shell is zsh
+#?   (zsh cannot export functions).
+#?   Under bash parents the exported xsh function takes precedence over this
+#?   shim, so it is harmless to keep it on PATH for both shells.
+#?
+#? Usage:
+#?   xsh <LPUE> [UTIL_OPTIONS]
+#?
+
+export XSH_HOME=${XSH_HOME:-${HOME}/.xsh}
+export XSH_DEV_HOME=${XSH_DEV_HOME:-${XSH_HOME}/lib-dev}
+
+# shellcheck source=/dev/null
+source "${XSH_HOME}/xsh/xsh.sh"
+
+xsh "$@"

--- a/completions/_xsh
+++ b/completions/_xsh
@@ -1,5 +1,9 @@
 #compdef xsh
 
+# Zsh tab-completion for `xsh`.
+# Registered by ~/.xshrc: the completions directory is added to fpath (picked
+# up by compinit), or bound directly with compdef if compinit has already run.
+
 _xsh() {
     local state
 
@@ -7,20 +11,22 @@ _xsh() {
         '1: :->command' \
         '*: :->args'
 
+    # The sed strips ANSI color codes defensively - xsh ≤ 0.6.1 emitted bold
+    # around every `xsh list` line even when stdout wasn't a TTY.
     case $state in
         command)
             local builtins
-            builtins=(load unload update list imports unimports help debug version versions upgrade calls call exec log lib-manager lib-dev-manager)
+            builtins=(load unload update list imports unimports import unimport help debug version versions upgrade calls call exec log lib-manager lib-dev-manager)
             local lpues
-            lpues=(${(f)"$(xsh list '*' 2>/dev/null | awk '{print $2}')"})
+            lpues=(${(f)"$(xsh list '*' 2>/dev/null | sed $'s/\033\\[[0-9;]*[a-zA-Z]//g' | awk '{print $2}')"})
             _describe 'command' builtins
             _describe 'utility' lpues
             ;;
         args)
             case $words[2] in
-                help|list)
+                help|list|imports|unimports|import|unimport|calls)
                     local lpues
-                    lpues=(${(f)"$(xsh list '*' 2>/dev/null | awk '{print $2}')"})
+                    lpues=(${(f)"$(xsh list '*' 2>/dev/null | sed $'s/\033\\[[0-9;]*[a-zA-Z]//g' | awk '{print $2}')"})
                     _describe 'utility' lpues
                     ;;
                 load)

--- a/install.sh
+++ b/install.sh
@@ -155,6 +155,9 @@ function uninstall-xsh () {
     printf "cleaning in: %s\n" ~/.bashrc
     clean-in-profile ~/.bashrc
 
+    printf "cleaning in: %s\n" ~/.zshrc
+    clean-in-profile ~/.zshrc
+
     printf "removing: %s\n" ~/.xshrc
     /bin/rm -f ~/.xshrc
 
@@ -182,9 +185,13 @@ function install-xsh () {
     printf "updating: %s\n" ~/.bashrc
     update-profile ~/.bashrc
 
+    printf "updating: %s\n" ~/.zshrc
+    update-profile ~/.zshrc
+
     # Bash completion is now auto-sourced by ~/.xshrc (see .xshrc); the previous
     # /etc/bash_completion.d/ copy was redundant on Linux and a no-op on macOS
     # (no such dir on stock macOS; Homebrew uses $(brew --prefix)/etc/...).
+    # Zsh completion (completions/_xsh) is registered in fpath by ~/.xshrc.
 }
 
 function main () {

--- a/spec/install_spec.sh
+++ b/spec/install_spec.sh
@@ -5,12 +5,23 @@
 #?   shellspec --kcov -s /bin/bash spec/install_spec.sh
 #?
 Describe 'installer'
-  exported_functions () { declare -Fx | awk '{print $3}'; }
-  uninstall () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -u >/dev/null; unset -f xsh; unset XSH_HOME XSH_DEV_HOME; }
+  # zsh cannot export functions to the environment, so the equivalent check
+  # under zsh is "is the function defined" (`typeset +f` lists the names).
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    exported_functions () { typeset +f; }
+  else
+    exported_functions () { declare -Fx | awk '{print $3}'; }
+  fi
+  # `unset -f` of an undefined function: bash is silent, zsh prints an error
+  uninstall () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -u >/dev/null; unset -f xsh 2>/dev/null || :; unset XSH_HOME XSH_DEV_HOME; }
   AfterAll 'uninstall'
 
   Describe 'install.sh'
     It 'run install.sh'
+      # the default install upgrades to the latest released tag, whose xsh.sh
+      # predates zsh support and cannot be sourced under zsh.
+      # Remove this skip after the first zsh-supporting release.
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       # shellcheck source=/dev/null
       install () { uninstall; bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh; . ~/.xshrc; }
       When call install
@@ -26,6 +37,8 @@ Describe 'installer'
     End
 
     It 'run install.sh -f'
+      # see the skip note in 'run install.sh'
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       # shellcheck source=/dev/null
       install () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -f; . ~/.xshrc; }
       When call install
@@ -41,8 +54,9 @@ Describe 'installer'
     End
 
     It 'run install.sh -s'
-      # shellcheck source=/dev/null
-      install () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -s; . ~/.xshrc; }
+      # `-f` first: the previous example is skipped under zsh, leaving the
+      # XSH_HOME of its own former run in place, which `-s` alone refuses
+      install () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -f -s; . ~/.xshrc; }
       When call install
       The status should be success
       The output should include ''
@@ -52,10 +66,14 @@ Describe 'installer'
       The path "${XSH_HOME}" should be directory
       The path "${XSH_HOME}"/xsh/xsh.sh should be file
       The path "${XSH_DEV_HOME}" should be directory
+      The contents of file ~/.zshrc should include '. ~/.xshrc'
       The result of function exported_functions should include 'xsh'
     End
 
     It 'run install.sh -b master'
+      # see the skip note in 'run install.sh' - applies to the master branch
+      # tip as well, until the zsh support is merged into master
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       # shellcheck source=/dev/null
       install () { bash "${SHELLSPEC_PROJECT_ROOT}"/install.sh -b master; . ~/.xshrc; }
       When call install
@@ -73,6 +91,9 @@ Describe 'installer'
 
   Describe 'boot'
     It 'run boot through web'
+      # see the skip note in 'run install.sh' - boot installs from the
+      # published master branch, which predates zsh support until merged
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       # shellcheck source=/dev/null
       install () { curl -s https://raw.githubusercontent.com/alexzhangs/xsh/master/boot | bash -s -- -f && . ~/.xshrc; }
       When call install

--- a/spec/xsh_func_spec.sh
+++ b/spec/xsh_func_spec.sh
@@ -5,8 +5,16 @@
 #?   shellspec --kcov -s /bin/bash spec/xsh_func_spec.sh
 #?
 Describe 'xsh.sh'
-  Include xsh.sh
-  exported_functions () { declare -Fx | awk '{print $3}'; }
+  # `./`-prefixed: zsh's `.` builtin searches only PATH (not CWD) for
+  # unprefixed names, while bash falls back to CWD
+  Include ./xsh.sh
+  # zsh cannot export functions to the environment, so the equivalent check
+  # under zsh is "is the function defined" (`typeset +f` lists the names).
+  if [ -n "${ZSH_VERSION:-}" ]; then
+    exported_functions () { typeset +f; }
+  else
+    exported_functions () { declare -Fx | awk '{print $3}'; }
+  fi
 
   Describe 'environments'
     It 'show XSH environment variables'
@@ -205,6 +213,9 @@ Describe 'xsh.sh'
     End
 
     It 'call /file/inject'
+      # x/file/inject depends on xsh-lib/core's x/trap/return, which uses the
+      # bash-only RETURN trap; needs an xsh-lib/core update to work under zsh
+      Skip if "x/file/inject depends on the bash-only RETURN trap" [ -n "${ZSH_VERSION:-}" ]
       BeforeCall 'touch /tmp/.xsh-file-inject'
       AfterCall 'rm -f /tmp/.xsh-file-inject'
       When call xsh /file/inject -c bar -p end /tmp/.xsh-file-inject
@@ -240,16 +251,18 @@ Describe 'xsh.sh'
       The output should equal ''
     End
 
+    # `h` (bash hashall) is on by default in bash scripts and shows in `$-`;
+    # zsh has no `h` in its `$-`, so it is correctly reported as off there
     It 'call shell-option h +v -x'
       When call xsh shell-option h +v -x
       The status should be success
-      The output should equal '-h +vx'
+      The output should equal "$([ -n "${ZSH_VERSION:-}" ] && echo '+hvx' || echo '-h +vx')"
     End
 
     It 'call shell-option h'
       When call xsh shell-option h
       The status should be success
-      The output should equal '-h'
+      The output should equal "$([ -n "${ZSH_VERSION:-}" ] && echo '+h' || echo '-h')"
     End
 
     It 'call shell-option +v -x'
@@ -1150,6 +1163,10 @@ Describe 'xsh.sh'
     End
 
     It 'upgrade xsh to latest stable version'
+      # `xsh upgrade` checks out the latest released tag and re-sources its
+      # xsh.sh - released versions predating zsh support cannot be sourced
+      # under zsh. Remove this skip after the first zsh-supporting release.
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       When call xsh upgrade
       The status should be success
       The output should not equal ''
@@ -1157,6 +1174,9 @@ Describe 'xsh.sh'
     End
 
     It 'upgrade xsh to latest version'
+      # see the skip note above - applies to the master branch tip as well,
+      # until the zsh support is merged into master
+      Skip if "released xsh versions predate zsh support" [ -n "${ZSH_VERSION:-}" ]
       When call xsh upgrade -b master
       The status should be success
       The output should not equal ''

--- a/spec/xsh_func_spec.sh
+++ b/spec/xsh_func_spec.sh
@@ -213,9 +213,8 @@ Describe 'xsh.sh'
     End
 
     It 'call /file/inject'
-      # x/file/inject depends on xsh-lib/core's x/trap/return, which uses the
-      # bash-only RETURN trap; needs an xsh-lib/core update to work under zsh
-      Skip if "x/file/inject depends on the bash-only RETURN trap" [ -n "${ZSH_VERSION:-}" ]
+      # NOTE: under zsh this needs xsh-lib/core > 0.5.0 (x/trap/return ported
+      # to zsh with a cascade of function-scoped EXIT traps)
       BeforeCall 'touch /tmp/.xsh-file-inject'
       AfterCall 'rm -f /tmp/.xsh-file-inject'
       When call xsh /file/inject -c bar -p end /tmp/.xsh-file-inject

--- a/xsh.sh
+++ b/xsh.sh
@@ -3,6 +3,8 @@
 
 #? Description:
 #?   xsh is an extension of Bash. It works as a Bash library framework.
+#?   It also runs under zsh: the xsh function and the imported utilities
+#?   are executed with zsh's ksh emulation enabled.
 #?
 #? Usage:
 #?   xsh <LPUE> [UTIL_OPTIONS]
@@ -101,6 +103,22 @@
 #?       * call, import, unimport, lib_list, help_lib
 #?
 function xsh () {
+
+    # zsh compatibility:
+    #   Run xsh and all its internal functions under ksh emulation: 0-indexed
+    #   arrays and word splitting on unquoted expansions, as bash behaves.
+    #   `emulate -L` scopes the emulation (options and traps) to this function
+    #   and everything called from it, and restores the caller's options when
+    #   xsh() returns.
+    #   NO_POSIX_TRAPS makes `trap ... EXIT` set inside a function fire on the
+    #   function's return (zsh-native semantics), which is required by the
+    #   cleanup trap at the end of this function.
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # shellcheck disable=SC3044
+        emulate -L ksh
+        # shellcheck disable=SC3044
+        setopt no_posix_traps
+    fi
 
     #? Special Variables:
     #?
@@ -236,7 +254,7 @@ function xsh () {
         declare mime_type ret=0
         mime_type=$(__xsh_mime_type "$(command -v "$1")" 2>/dev/null)
 
-        if [[ $(type -t "$1" || :) == file && ${mime_type%%/*} == text ]]; then
+        if [[ $(__xsh_type_t "$1" || :) == file && ${mime_type%%/*} == text ]]; then
             # call script with shell options enabled
             bash "${options[@]}" "$(command -v "$1")" "${@:2}"
             ret=$?
@@ -295,6 +313,12 @@ function xsh () {
     #?   __xsh_count_in_funcstack <FUNCNAME>
     #?
     function __xsh_count_in_funcstack () {
+        # zsh: build FUNCNAME from zsh's funcstack
+        # NOTE: this function may run from a zsh EXIT trap with zsh-native
+        # options - only whole-array (quoted) expansions are used here.
+        # shellcheck disable=SC2034,SC2154
+        [[ -n ${ZSH_VERSION-} ]] && declare -a FUNCNAME=( "${funcstack[@]}" )
+
         printf '%s\n' "${FUNCNAME[@]}" \
             | grep -c "^${1}$"
     }
@@ -302,6 +326,9 @@ function xsh () {
     #? Description:
     #?   Fire the command on the RETURN signal of function `xsh`.
     #?   The trapped command is cleared after it's fired once.
+    #?   This function is bash-only: zsh has no RETURN trap, the zsh
+    #?   counterpart is the function-scoped EXIT trap set in the main
+    #?   code of xsh().
     #?
     #? Usage:
     #?   __xsh_trap_return [COMMAND]
@@ -323,6 +350,11 @@ function xsh () {
     #?   __xsh_log [debug|info|warning|error|fail|fatal] <MESSAGE>
     #?
     function __xsh_log () {
+        # zsh: build FUNCNAME from zsh's funcstack (0-indexed under the ksh
+        # emulation set by xsh(), so the indexes match bash's FUNCNAME)
+        # shellcheck disable=SC2034
+        [[ -n ${ZSH_VERSION-} ]] && declare -a FUNCNAME=( "${funcstack[@]}" )
+
         declare level
         level=$(echo "$1" | tr "[:lower:]" "[:upper:]")
 
@@ -344,6 +376,61 @@ function xsh () {
                 printf "${caller}: %s\n" "$*"
                 ;;
         esac
+    }
+
+    #? Description:
+    #?   Portable replacement for bash `type -t`.
+    #?   Output the type of a command: `alias`, `keyword`, `function`,
+    #?   `builtin` or `file`, and return 0.
+    #?   Output nothing and return > 0 if the command is not found.
+    #?
+    #? Usage:
+    #?   __xsh_type_t <NAME>
+    #?
+    function __xsh_type_t () {
+        if [[ -n ${ZSH_VERSION-} ]]; then
+            # `whence -w` outputs `<name>: <type>`; map zsh types to bash's
+            declare out
+            out=$(whence -w "${1:?}" 2>/dev/null) || return
+            out=${out##*: }
+            case ${out} in
+                command|hashed)
+                    echo file
+                    ;;
+                reserved)
+                    echo keyword
+                    ;;
+                none)
+                    return 1
+                    ;;
+                *)
+                    # function, builtin, alias
+                    echo "${out}"
+                    ;;
+            esac
+        else
+            type -t "${1:?}"
+        fi
+    }
+
+    #? Description:
+    #?   Test if the given variable is exported.
+    #?
+    #? Usage:
+    #?   __xsh_is_exported <NAME>
+    #?
+    #? Return:
+    #?   0:               Exported.
+    #?   != 0:            Not exported.
+    #?
+    function __xsh_is_exported () {
+        declare -a out
+        # do not double quote the command substitution
+        # shellcheck disable=SC2207
+        out=( $(declare -p "${1:?}" 2>/dev/null) )
+
+        # bash: `declare -x NAME=...`; zsh: `export NAME=...` or `typeset -x NAME=...`
+        [[ ${out[0]} == export || ${out[1]} == -*x* ]]
     }
 
     #? Description:
@@ -683,7 +770,7 @@ function xsh () {
         declare topic
         if [[ $# -gt 0 ]]; then
             # get the last argument
-            topic=${!#}
+            topic=${*: -1}
 
             # remove the last argument from argument list
             set -- "${@:1:$#-1}"
@@ -697,7 +784,7 @@ function xsh () {
         {
             if [[ -z ${topic} ]]; then
                 __xsh_help_self_cache
-            elif [[ $(type -t "__xsh_${topic//-/_}" || :) == function ]]; then
+            elif [[ $(__xsh_type_t "__xsh_${topic//-/_}" || :) == function ]]; then
                 __xsh_help_builtin "$@" "__xsh_${topic//-/_}"
             else
                 __xsh_help_lib "$@" "${topic}"
@@ -716,7 +803,7 @@ function xsh () {
     #?   __xsh_sha1sum [OPTIONS]
     #?
     function __xsh_sha1sum () {
-        if type -t sha1sum >/dev/null; then
+        if __xsh_type_t sha1sum >/dev/null; then
             sha1sum "$@"
         else
             shasum "$@"
@@ -757,6 +844,10 @@ function xsh () {
     #?   __xsh_help_self_cache
     #?
     function __xsh_help_self_cache () {
+        # zsh: build FUNCNAME from zsh's funcstack
+        # shellcheck disable=SC2034
+        [[ -n ${ZSH_VERSION-} ]] && declare -a FUNCNAME=( "${funcstack[@]}" )
+
         declare hash cached_help
 
         # shellcheck disable=SC2207
@@ -822,7 +913,7 @@ function xsh () {
     #?
     function __xsh_help_builtin () {
         # get the last argument
-        declare builtin=${!#}
+        declare builtin=${*: -1}
         # remove the last argument from argument list
         declare -a options=( "${@:1:$#-1}" )
 
@@ -846,12 +937,12 @@ function xsh () {
 
         function __xsh_help_lib__ () {
             # get the last argument
-            declare lpur=${!#}
+            declare lpur=${*: -1}
             # remove the last argument from argument list
             declare -a options=( "${@:1:$#-1}" )
 
-            declare path
-            path=$(__xsh_get_path_by_lpur "${lpur}")
+            declare lpu_path
+            lpu_path=$(__xsh_get_path_by_lpur "${lpur}")
             declare ln
             while read -r ln; do
                 if [[ -n ${ln} ]]; then
@@ -860,23 +951,23 @@ function xsh () {
                     lpue=$(__xsh_get_lpue_by_path "${ln}")
 
                     if [[ -z ${util} ]]; then
-                        __xsh_log error "util is null: %s." "${path}"
+                        __xsh_log error "util is null: %s." "${lpu_path}"
                         return 255
                     fi
 
                     if [[ -z ${lpue} ]]; then
-                        __xsh_log error "lpue is null: %s." "${path}"
+                        __xsh_log error "lpue is null: %s." "${lpu_path}"
                         return 255
                     fi
 
                     __xsh_info "${options[@]}" "${ln}" \
                         | sed "s|@${util}|xsh ${lpue}|g"
                 fi
-            done <<< "${path}"
+            done <<< "${lpu_path}"
         }
 
         # get the last argument
-        declare lpur=${!#}
+        declare lpur=${*: -1}
 
         if __xsh_is_dev "${lpur}"; then
             XSH_LIB_HOME=${XSH_DEV_HOME} __xsh_help_lib__ "$@"
@@ -935,10 +1026,10 @@ function xsh () {
         }
 
         # get the last argument
-        declare path=${!#} funcname \
+        declare lpu_path=${*: -1} funcname \
                 OPTIND OPTARG opt
 
-        if [[ -z ${path} || ${path:1:1} == - ]]; then
+        if [[ -z ${lpu_path} || ${lpu_path:1:1} == - ]]; then
             __xsh_log error "LPU path is null or not set."
             return 255
         fi
@@ -951,9 +1042,9 @@ function xsh () {
                 t|T)
                     declare title
                     if [[ -n ${funcname} ]]; then
-                        title=$(__xsh_get_funcname_from_file "${path}" "${funcname}")
+                        title=$(__xsh_get_funcname_from_file "${lpu_path}" "${funcname}")
                     else
-                        title=$(__xsh_get_title_by_path "${path}")
+                        title=$(__xsh_get_title_by_path "${lpu_path}")
                     fi
 
                     if [[ ${opt} == t ]]; then
@@ -966,23 +1057,23 @@ function xsh () {
                     ;;
                 d)
                     if [[ -n ${funcname} ]]; then
-                        __xsh_get_doc_from_file "${path}" "${funcname}"
+                        __xsh_get_doc_from_file "${lpu_path}" "${funcname}"
                     else
-                        awk '/^#\?/ {sub("^[ ]*#\\?[ ]?", ""); print}' "${path}"
+                        awk '/^#\?/ {sub("^[ ]*#\\?[ ]?", ""); print}' "${lpu_path}"
                     fi
                     ;;
                 c)
                     if [[ -n ${funcname} ]]; then
-                        __xsh_get_funccode_from_file "${path}" "${funcname}"
+                        __xsh_get_funccode_from_file "${lpu_path}" "${funcname}"
                     else
-                        sed '/^#?/d' "${path}"
+                        sed '/^#?/d' "${lpu_path}"
                     fi
                     ;;
                 s)
-                    __xsh_info -f "${funcname}" -d "${path}" | __xsh_filter_section_with_title__ "${OPTARG}"
+                    __xsh_info -f "${funcname}" -d "${lpu_path}" | __xsh_filter_section_with_title__ "${OPTARG}"
                     ;;
                 S)
-                    __xsh_info -f "${funcname}" -d "${path}" | __xsh_filter_section_without_title__ "${OPTARG}"
+                    __xsh_info -f "${funcname}" -d "${lpu_path}" | __xsh_filter_section_without_title__ "${OPTARG}"
                     ;;
                 i)
                     if [[ -n ${funcname} ]]; then
@@ -1018,12 +1109,12 @@ function xsh () {
     #?                    rather than the list order.
     #?
     function __xsh_get_funcname_from_file () {
-        declare path=${1:?} funcname=$2
+        declare lpu_path=${1:?} funcname=$2
 
         awk -v nameregex="^(${funcname//,/|})$" '{
             if ($1 == "function" && $2 ~ nameregex)
                 print "[functions]" FS $2
-        }' "${path}"
+        }' "${lpu_path}"
     }
 
     #? Description:
@@ -1041,7 +1132,7 @@ function xsh () {
     #?                    rather than the list order.
     #?
     function __xsh_get_funccode_from_file () {
-        declare path=${1:?} funcname=$2
+        declare lpu_path=${1:?} funcname=$2
 
         awk -v nameregex="^(${funcname//,/|})$" -v indent=-1 '{
             if ($1 == "function" && $2 ~ nameregex) {
@@ -1056,7 +1147,7 @@ function xsh () {
                     indent = -1
                 }
             }
-        }' "${path}"
+        }' "${lpu_path}"
     }
 
     #? Description:
@@ -1075,7 +1166,7 @@ function xsh () {
     #?                    rather than the list order.
     #?
     function __xsh_get_doc_from_file () {
-        declare path=${1:?} funcname=$2
+        declare lpu_path=${1:?} funcname=$2
 
         awk -v nameregex="^(${funcname//,/|})$" '{
             if (str && $1 == "function" && $2 ~ nameregex) {
@@ -1088,7 +1179,7 @@ function xsh () {
             } else {
                 str = ""
             }
-        }' "${path}"
+        }' "${lpu_path}"
     }
 
     #? Description:
@@ -1180,11 +1271,11 @@ function xsh () {
     #?   __xsh_lib_list
     #?
     function __xsh_lib_list () {
-        declare path
+        declare lpu_path
         if __xsh_is_dev; then
-            path=$(find "${XSH_DEV_HOME}" -maxdepth 1 -type l)
+            lpu_path=$(find "${XSH_DEV_HOME}" -maxdepth 1 -type l)
         else
-            path=$(find "${XSH_LIB_HOME}" -maxdepth 1 -type l)
+            lpu_path=$(find "${XSH_LIB_HOME}" -maxdepth 1 -type l)
         fi
 
         declare lib lib_path repo version
@@ -1198,7 +1289,7 @@ function xsh () {
                        | awk -F/ '{print $(NF-1) FS $NF}')
 
             printf '%s (%s) => %s\n' "${lib}" "${version:-latest}" "${repo}"
-        done <<< "${path}"
+        done <<< "${lpu_path}"
     }
 
     #? Description:
@@ -1317,7 +1408,7 @@ function xsh () {
     #?
     function __xsh_load () {
         # get the last argument
-        declare repo=${!#}
+        declare repo=${*: -1}
 
         if [[ -z ${repo} ]]; then
             __xsh_log error "Repo name is null or not set."
@@ -1374,7 +1465,7 @@ function xsh () {
     #?
     function __xsh_update () {
         # get the last argument
-        declare repo=${!#}
+        declare repo=${*: -1}
 
         if [[ -z ${repo} ]]; then
             __xsh_log error "Repo name is null or not set."
@@ -1446,7 +1537,9 @@ function xsh () {
 
         declare index init_file
         for (( index = "${#scopes[@]}"; index >= 0; index-- )); do
-            scope=${scopes[*]:0:index}
+            # use `$((index))` rather than a bare `index` - zsh doesn't
+            # evaluate bare identifiers in the offset/length of `${var:off:len}`
+            scope=${scopes[*]:0:$((index))}
             # replace all whitespace to slash `/`
             init_file=${XSH_LIB_HOME}/${scope// //}/__init__.sh
 
@@ -1478,12 +1571,12 @@ function xsh () {
     #?   <FILE>           Path to the function utility.
     #?
     function __xsh_make_init () {
-        declare path=${1:?} code util lpuc
+        declare lpu_path=${1:?} code util lpuc
 
-        util=$(__xsh_get_util_by_path "${path}")
-        lpuc=$(__xsh_get_lpuc_by_path "${path}")
+        util=$(__xsh_get_util_by_path "${lpu_path}")
+        lpuc=$(__xsh_get_lpuc_by_path "${lpu_path}")
 
-        code=$(__xsh_info -c "${path}")
+        code=$(__xsh_info -c "${lpu_path}")
 
         declare init_file
         while read -r init_file; do
@@ -1505,7 +1598,7 @@ function xsh () {
             # remember the applied init file
             # do not declare it, make it global
             code="__XSH_INIT__+=( \"${init_file}\" )"$'\n'"${code}"
-        done < <(__xsh_get_init_files "${path%/*}")
+        done < <(__xsh_get_init_files "${lpu_path%/*}")
 
         printf '%s' "${code}"
     }
@@ -1553,8 +1646,8 @@ function xsh () {
     function __xsh_import () {
 
         function __xsh_import__ () {
-            declare lpur=${1:?} path
-            path=$(__xsh_get_path_by_lpur "${lpur}")
+            declare lpur=${1:?} lpu_path
+            lpu_path=$(__xsh_get_path_by_lpur "${lpur}")
 
             declare ln type
             while read -r ln; do
@@ -1575,7 +1668,7 @@ function xsh () {
                         return 255
                         ;;
                 esac
-            done <<< "${path}"
+            done <<< "${lpu_path}"
         }
 
         declare lpur=$1
@@ -1603,11 +1696,11 @@ function xsh () {
     #?   <FILE>           Path to the function utility.
     #?
     function __xsh_import_function () {
-        declare path=${1:?}
+        declare lpu_path=${1:?}
 
         # source the function
         # shellcheck source=/dev/null
-        source /dev/stdin <<< "$(__xsh_make_function "${path}")"
+        source /dev/stdin <<< "$(__xsh_make_function "${lpu_path}")"
     }
 
     #? Descriptions:
@@ -1626,13 +1719,13 @@ function xsh () {
     #?   The changed code.
     #?
     function __xsh_make_function () {
-        declare path=${1:?} code util lpuc
+        declare lpu_path=${1:?} code util lpuc
 
-        util=$(__xsh_get_util_by_path "${path}")
-        lpuc=$(__xsh_get_lpuc_by_path "${path}")
+        util=$(__xsh_get_util_by_path "${lpu_path}")
+        lpuc=$(__xsh_get_lpuc_by_path "${lpu_path}")
 
         # apply init files if found
-        code=$(__xsh_make_init "${path}")
+        code=$(__xsh_make_init "${lpu_path}")
 
         # renaming function name
         code=$(sed -e "s/^function ${util} ()/function ${lpuc} ()/g" \
@@ -1649,10 +1742,20 @@ function xsh () {
             options=( ${decorator} )
 
             code=$(__xsh_apply_func_decorator "${options[0]}" "${code:?}" "${options[@]:1}")
-        done < <(__xsh_get_decorators "${path}")
+        done < <(__xsh_get_decorators "${lpu_path}")
 
-        # export function to sub-processes
-        printf "%s\n%s\n" "${code}" "export -f ${lpuc}"
+        if [[ -n ${ZSH_VERSION-} ]]; then
+            # run the (bash-flavored) utility under ksh emulation in zsh;
+            # the line is inserted as the first line of the function body,
+            # ahead of any decorator code
+            code=$(sed "/^function [_0-9a-zA-Z-]* ()/ r /dev/stdin" <(printf '%s' "${code:?}") <<< "    emulate -L ksh")
+
+            # zsh cannot export functions to sub-processes
+            printf "%s\n" "${code}"
+        else
+            # export function to sub-processes
+            printf "%s\n%s\n" "${code}" "export -f ${lpuc}"
+        fi
     }
 
     #? Description:
@@ -1686,10 +1789,10 @@ function xsh () {
     #?   <FILE>           File path.
     #?
     function __xsh_get_decorators () {
-        declare path=${1:?}
+        declare lpu_path=${1:?}
 
         # filter the pattern `#? @foo bar` and output the part `foo bar`
-        awk '/^#\? @.+/ {sub(/^#\? @/, ""); print $0}' "${path}"
+        awk '/^#\? @.+/ {sub(/^#\? @/, ""); print $0}' "${lpu_path}"
     }
 
     #? Description:
@@ -1711,7 +1814,7 @@ function xsh () {
     function __xsh_apply_func_decorator () {
         declare name=${1:?}
 
-        if [[ $(type -t "__xsh_func_decorator_${name}" || :) == function ]]; then
+        if [[ $(__xsh_type_t "__xsh_func_decorator_${name}" || :) == function ]]; then
             # applying the decorator
             __xsh_func_decorator_"${name}" "${@:2}"
         else
@@ -1822,16 +1925,16 @@ function xsh () {
     #?   __xsh_import_script <FILE>
     #?
     function __xsh_import_script () {
-        declare path=$1
+        declare lpu_path=$1
         declare lpuc
 
-        if [[ -z ${path} ]]; then
+        if [[ -z ${lpu_path} ]]; then
             __xsh_log error "LPU path is null or not set."
             return 255
         fi
 
-        lpuc=$(__xsh_get_lpuc_by_path "${path}")
-        ln -sf "${path}" "/usr/local/bin/${lpuc}"
+        lpuc=$(__xsh_get_lpuc_by_path "${lpu_path}")
+        ln -sf "${lpu_path}" "/usr/local/bin/${lpuc}"
     }
 
     #? Description:
@@ -1866,8 +1969,8 @@ function xsh () {
     function __xsh_unimport () {
 
         function __xsh_unimport__ () {
-            declare lpur=${1:?} path
-            path=$(__xsh_get_path_by_lpur "${lpur}")
+            declare lpur=${1:?} lpu_path
+            lpu_path=$(__xsh_get_path_by_lpur "${lpur}")
 
             declare ln type
             while read -r ln; do
@@ -1887,7 +1990,7 @@ function xsh () {
                         return 255
                         ;;
                 esac
-            done <<< "${path}"
+            done <<< "${lpu_path}"
         }
 
         declare lpur=$1
@@ -1912,12 +2015,12 @@ function xsh () {
     #?   __xsh_unimport_function <FILE>
     #?
     function __xsh_unimport_function () {
-        declare path=${1:?} util lpuc
+        declare lpu_path=${1:?} util lpuc
 
-        util=$(__xsh_get_util_by_path "${path}")
-        lpuc=$(__xsh_get_lpuc_by_path "${path}")
+        util=$(__xsh_get_util_by_path "${lpu_path}")
+        lpuc=$(__xsh_get_lpuc_by_path "${lpu_path}")
         # shellcheck source=/dev/null
-        source /dev/stdin <<< "$(sed -n "s/^function ${util} ().*/unset -f ${lpuc}/p" "${path}")"
+        source /dev/stdin <<< "$(sed -n "s/^function ${util} ().*/unset -f ${lpuc}/p" "${lpu_path}")"
     }
 
     #? Description:
@@ -1928,9 +2031,9 @@ function xsh () {
     #?   __xsh_unimport_script <FILE>
     #?
     function __xsh_unimport_script () {
-        declare path=${1:?} lpuc
+        declare lpu_path=${1:?} lpuc
 
-        lpuc=$(__xsh_get_lpuc_by_path "${path}")
+        lpuc=$(__xsh_get_lpuc_by_path "${lpu_path}")
         rm -f "/usr/local/bin/${lpuc}"
 
         # forget remembered commands locations
@@ -1959,10 +2062,7 @@ function xsh () {
         declare input=${1:?}
         input=$(__xsh_complete_lpue "${input}")
 
-        declare xsh_debug
-        xsh_debug=$(declare -p XSH_DEBUG 2>/dev/null)
-
-        if [[ ${xsh_debug} =~ ^declare\ -x ]]; then
+        if __xsh_is_exported XSH_DEBUG; then
             case ${XSH_DEBUG} in
                 1)
                     XSH_DEBUG=( "${input}" )
@@ -2003,10 +2103,7 @@ function xsh () {
             input=$(__xsh_complete_lpue "${input}")
         fi
 
-        declare xsh_dev
-        xsh_dev=$(declare -p XSH_DEV 2>/dev/null)
-
-        if [[ ${xsh_dev} =~ ^declare\ -x ]]; then
+        if __xsh_is_exported XSH_DEV; then
             case ${XSH_DEV} in
                 1)
                     # set to the exact input
@@ -2117,7 +2214,7 @@ function xsh () {
 
         if [[ ${import} -eq 1 ]]; then
             __xsh_import "${lpue}"
-        elif ! type -t "${lpuc}" >/dev/null; then
+        elif ! __xsh_type_t "${lpuc}" >/dev/null; then
             __xsh_import "${lpue}"
         fi
 
@@ -2132,7 +2229,7 @@ function xsh () {
                 __xsh_call_with_shell_option -0 vx "${lpuc}" "${@:2}"
             fi
         else
-            if [[ $(type -t "${lpuc}" || :) == file && ${mime_type%%/*} == text ]]; then
+            if [[ $(__xsh_type_t "${lpuc}" || :) == file && ${mime_type%%/*} == text ]]; then
                 # call script
                 bash "$(command -v "${lpuc}")" "${@:2}"
             else
@@ -2166,7 +2263,11 @@ function xsh () {
         lpur=$(__xsh_complete_lpue "${lpur}")
 
         # append `*` if the lpur is ended with slash `/`
-        lpur=${lpur/%\//\/*}
+        # (avoid `${var/%pat/repl}` with a backslash in repl - zsh keeps the
+        # backslash literally while bash drops it)
+        if [[ ${lpur} == */ ]]; then
+            lpur=${lpur}\*
+        fi
 
         if [[ -n ${lpur##*\/*} ]]; then
             # append `/*` if the lpur doesn't contain any slash `/`
@@ -2299,16 +2400,16 @@ function xsh () {
     #?   __xsh_get_title_by_path <PATH>
     #?
     function __xsh_get_title_by_path () {
-        declare path=$1
+        declare lpu_path=$1
 
-        if [[ -z ${path} ]]; then
+        if [[ -z ${lpu_path} ]]; then
             __xsh_log error "LPU path is null or not set."
             return 255
         fi
 
         declare type lpue
-        type=$(__xsh_get_type_by_path "${path}")
-        lpue=$(__xsh_get_lpue_by_path "${path}")
+        type=$(__xsh_get_type_by_path "${lpu_path}")
+        lpue=$(__xsh_get_lpue_by_path "${lpu_path}")
 
         printf '[%s] %s\n' "${type}" "${lpue}"
     }
@@ -2321,14 +2422,14 @@ function xsh () {
     #?   __xsh_get_type_by_path <PATH>
     #?
     function __xsh_get_type_by_path () {
-        declare path=$1 type
+        declare lpu_path=$1 type
 
-        if [[ -z ${path} ]]; then
+        if [[ -z ${lpu_path} ]]; then
             __xsh_log error "LPU path is null or not set."
             return 255
         fi
 
-        type=${path#"${XSH_LIB_HOME}"/*/}  # strip path from beginning
+        type=${lpu_path#"${XSH_LIB_HOME}"/*/}  # strip path from beginning
         echo "${type%%/*}"  # strip path from end
     }
 
@@ -2353,9 +2454,9 @@ function xsh () {
     #?   __xsh_get_util_by_path <PATH>
     #?
     function __xsh_get_util_by_path () {
-        declare path=${1:?} util
+        declare lpu_path=${1:?} util
 
-        util=${path%.sh}  # remove file extension
+        util=${lpu_path%.sh}  # remove file extension
         util=${util%/[0-9]*}  # handle util selector, started with digits
         echo "${util##*/}"  # get util
     }
@@ -2368,11 +2469,11 @@ function xsh () {
     #?   __xsh_get_lpue_by_path <PATH>
     #?
     function __xsh_get_lpue_by_path () {
-        declare path=${1:?} lib pue
+        declare lpu_path=${1:?} lib pue
 
-        lib=${path#"${XSH_LIB_HOME}"/}  # strip path from beginning
+        lib=${lpu_path#"${XSH_LIB_HOME}"/}  # strip path from beginning
         lib=${lib%%/*}  # remove anything after first / (include the /)
-        pue=${path#"${XSH_LIB_HOME}"/*/*/}  # strip path from beginning
+        pue=${lpu_path#"${XSH_LIB_HOME}"/*/*/}  # strip path from beginning
         pue=${pue%.sh}  # remove file extension
         echo "${lib}/${pue}"
     }
@@ -2385,9 +2486,9 @@ function xsh () {
     #?   __xsh_get_lpuc_by_path <PATH>
     #?
     function __xsh_get_lpuc_by_path () {
-        declare path=$1 lpue
+        declare lpu_path=$1 lpue
 
-        lpue=$(__xsh_get_lpue_by_path "${path}")
+        lpue=$(__xsh_get_lpue_by_path "${lpu_path}")
         __xsh_get_lpuc_by_lpue "${lpue}"
     }
 
@@ -2398,8 +2499,15 @@ function xsh () {
     #?   __xsh_get_internal_functions
     #?
     function __xsh_get_internal_functions () {
-        declare -f xsh \
-            | awk '$1 == "function" && match($2, "^__xsh_") > 0 && $3 == "()" {print $2}'
+        if [[ -n ${ZSH_VERSION-} ]]; then
+            # zsh's `declare -f` omits the `function` keyword, so the bash
+            # branch's awk wouldn't match; `typeset +f` lists all defined
+            # function names, one per line
+            typeset +f | grep '^__xsh_'
+        else
+            declare -f xsh \
+                | awk '$1 == "function" && match($2, "^__xsh_") > 0 && $3 == "()" {print $2}'
+        fi
     }
 
     #? Description:
@@ -2409,8 +2517,13 @@ function xsh () {
     #?   __xsh_clean
     #?
     function __xsh_clean () {
-        # shellcheck disable=SC2046
-        unset -f $(__xsh_get_internal_functions)
+        # NOTE: this function may run from a zsh EXIT trap with zsh-native
+        # options (no word splitting) - unset the functions one by one rather
+        # than relying on the word splitting of an unquoted expansion
+        declare funcname
+        while read -r funcname; do
+            unset -f "${funcname}"
+        done < <(__xsh_get_internal_functions)
         unset XSH_DEBUG
         unset XSH_DEV
     }
@@ -2420,11 +2533,23 @@ function xsh () {
 
     # call __xsh_clean() while xsh() returns
     # clean env if reaching the final exit point of xsh
-    # shellcheck disable=SC2016
-    __xsh_trap_return '
-            if [[ $(__xsh_count_in_funcstack xsh) -eq 1 ]]; then
+    if [[ -n ${ZSH_VERSION-} ]]; then
+        # zsh: with NO_POSIX_TRAPS (set at the top of this function), an EXIT
+        # trap set inside a function fires when that function returns, and is
+        # scoped to it (`emulate -L` sets LOCAL_TRAPS).
+        # The trap runs after this xsh() frame is popped off the funcstack, so
+        # a count of 0 means this is the outermost xsh call.
+        trap '
+            if [[ $(__xsh_count_in_funcstack xsh) -eq 0 ]]; then
                 __xsh_clean
-            fi;'
+            fi;' EXIT
+    else
+        # shellcheck disable=SC2016
+        __xsh_trap_return '
+                if [[ $(__xsh_count_in_funcstack xsh) -eq 1 ]]; then
+                    __xsh_clean
+                fi;'
+    fi
 
     # check environment variable
     if [[ -n ${XSH_HOME%/} ]]; then
@@ -2465,7 +2590,7 @@ function xsh () {
         set -- "${@:2}" "$1"
     fi
 
-    if [[ $(type -t "__xsh_${1//-/_}" || :) == function ]]; then
+    if [[ $(__xsh_type_t "__xsh_${1//-/_}" || :) == function ]]; then
         # xsh command or builtin function
         __xsh_"${1//-/_}" "${@:2}"
     else
@@ -2473,5 +2598,9 @@ function xsh () {
         __xsh_call "$1" "${@:2}"
     fi
 }
-# export function to sub-processes
-export -f xsh
+# export function to sub-processes (bash only)
+# zsh cannot export functions - sub-processes started from zsh call the
+# executable shim `bin/xsh` instead (put on PATH by ~/.xshrc)
+if [[ -n ${BASH_VERSION-} ]]; then
+    export -f xsh
+fi


### PR DESCRIPTION
Release **0.7.0**: zsh support — xsh now runs under zsh (macOS's default shell) via ksh emulation, in addition to bash 3.2+. See CHANGELOG `[0.7.0]` for details.

Merges the zsh-support work (#32) from develop to master for tagging. 🤖 Generated with [Claude Code](https://claude.com/claude-code)